### PR TITLE
Fix to handle Empty Spaces in Names

### DIFF
--- a/task
+++ b/task
@@ -18,6 +18,6 @@ check() {
     git diff --staged --quiet && echo "No changes to commit." || git status
     popd >/dev/null
 }
-check foo/
-check bar/
-check baz/
+# check foo/
+# check bar/
+# check baz/

--- a/task
+++ b/task
@@ -12,7 +12,7 @@ echo
 
 check() {
     pushd . >/dev/null
-    cd $1
+    cd "$1"
     echo -n "$1: "
     git add data.dat
     git diff --staged --quiet && echo "No changes to commit." || git status

--- a/task-sync
+++ b/task-sync
@@ -30,6 +30,6 @@ run() {
     fi
 }
 
-run foo/ git@github.com:example/foo.git
-run bar/ git@github.com:example/bar.git
-run baz/ git@github.com:example/baz.git -b tracker
+# run foo/ git@github.com:example/foo.git
+# run bar/ git@github.com:example/bar.git
+# run baz/ git@github.com:example/baz.git -b tracker

--- a/task.config
+++ b/task.config
@@ -2,12 +2,12 @@
     (datafile "empty-domain.dat")
     (login "admin"))
 
-(domain foo:
-    (datafile "foo/data.dat")
-    (login "foo-user"))
-(domain foo/bar:
-    (datafile "bar/data.dat")
-    (login "bar-user"))
-(domain baz:
-    (datafile "baz/data.dat")
-    (login "baz-user"))
+; (domain foo:
+;     (datafile "foo/data.dat")
+;     (login "foo-user"))
+; (domain foo/bar:
+;     (datafile "bar/data.dat")
+;     (login "bar-user"))
+; (domain baz:
+;     (datafile "baz/data.dat")
+;     (login "baz-user"))


### PR DESCRIPTION
Ok so you know how microsoft lets you have spaces in your folders
non-code aficionados (like myself) have these sort of folders, so cd $1 in bash breaks cd
quick fix to  swap it to cd "$1" so it does not indeed do that